### PR TITLE
Integrated profanity phrase matcher

### DIFF
--- a/profanity_filter/data/en_core_web_sm_profane_words.txt
+++ b/profanity_filter/data/en_core_web_sm_profane_words.txt
@@ -165,6 +165,7 @@ jizz
 kanker
 kawk
 kike
+kill
 klootzak
 knob
 knobz
@@ -348,6 +349,7 @@ slutty
 slutz
 smut
 sonofabitch
+suicide
 sx
 teets
 teez

--- a/profanity_filter/data/profanity_phrases.txt
+++ b/profanity_filter/data/profanity_phrases.txt
@@ -1,0 +1,7 @@
+stab yourself
+cut yourself
+kill yourself
+cut your arm
+die
+die now
+go die

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,17 @@
 from collections import defaultdict
 from copy import deepcopy
-from dataclasses import replace, dataclass
+from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Tuple
 
 import dill
 import pytest
 import spacy.language
 from ordered_set import OrderedSet
-
-from profanity_filter.profanity_filter import ProfanityFilter
-from profanity_filter.types_ import ProfaneWordDictionaries, AnalysesTypes, Language
 from profanity_filter import Config
+from profanity_filter.profanity_filter import ProfanityFilter
+from profanity_filter.types_ import (AnalysesTypes, Language,
+                                     ProfaneWordDictionaries)
 
 
 @dataclass
@@ -69,4 +70,5 @@ def with_config(config: Config):
 
 
 TEST_STATEMENT = "Hey, I like unicorns, chocolate, oranges and man's blood, turd!"
+TEST_STATEMENT_WITH_PROFANE_PHRASE = "Hey, cut your arm"
 CLEAN_STATEMENT = "Hey there, I like chocolate too mate."

--- a/tests/test_profanity_filter.py
+++ b/tests/test_profanity_filter.py
@@ -4,14 +4,15 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 from ordered_set import OrderedSet
+from profanity_filter.config import Config
+from profanity_filter.profanity_filter import DEFAULT_CONFIG, ProfanityFilter
+from profanity_filter.types_ import AnalysisType, Word
 from ruamel.yaml import YAML
 
-from profanity_filter.profanity_filter import ProfanityFilter, DEFAULT_CONFIG
-from profanity_filter.types_ import Word, AnalysisType
-from profanity_filter.config import Config
-
-from tests.conftest import (create_profane_word_dictionaries, TEST_STATEMENT, CLEAN_STATEMENT, with_config,
-                            Config as TestConfig)
+from tests.conftest import (CLEAN_STATEMENT, TEST_STATEMENT,
+                            TEST_STATEMENT_WITH_PROFANE_PHRASE)
+from tests.conftest import Config as TestConfig
+from tests.conftest import create_profane_word_dictionaries, with_config
 
 
 def compare_settings(pf0: ProfanityFilter, pf1: ProfanityFilter) -> None:
@@ -26,7 +27,6 @@ def compare_settings(pf0: ProfanityFilter, pf1: ProfanityFilter) -> None:
 
 def test_from_config():
     compare_settings(ProfanityFilter(), ProfanityFilter.from_config(DEFAULT_CONFIG))
-
 
 def test_from_yaml():
     non_existing_path = uuid.uuid4().hex
@@ -64,6 +64,11 @@ def test_censor_word(pf):
 @with_config(TestConfig())
 def test_is_profane(pf):
     assert pf.is_profane(TEST_STATEMENT)
+    assert not pf.is_profane(CLEAN_STATEMENT)
+
+@with_config(TestConfig())
+def test_is_profane_with_phrase(pf):
+    assert pf.is_profane(TEST_STATEMENT_WITH_PROFANE_PHRASE)
     assert not pf.is_profane(CLEAN_STATEMENT)
 
 


### PR DESCRIPTION
This enables our profanity filter to match certain phrases inside the text. It's an effective add-on on top of what they already do.